### PR TITLE
Optimize hasValue

### DIFF
--- a/.changeset/silent-jars-grow.md
+++ b/.changeset/silent-jars-grow.md
@@ -1,0 +1,5 @@
+---
+"pogchamp": patch
+---
+
+Optimize hasValue by leveraging boolean operators

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 /**
  * Check if variable has value. (if it's not undefined or null)
  */
-export const hasValue = (variable: any) => {
+export const hasValue = <T>(variable: T | undefined | null): variable is T => {
   return variable !== undefined && variable !== null
 }
 

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@
  * Check if variable has value. (if it's not undefined or null)
  */
 export const hasValue = (variable: any) => {
-  return ![undefined, null].includes(variable)
+  return variable !== undefined && variable !== null
 }
 
 /**


### PR DESCRIPTION
`Array#includes()` is highly inefficient when compared to just basic `&&`/`||`, especially with only two values. See benchmarks below:
![image](https://user-images.githubusercontent.com/65814829/214053156-a6fbeba6-d9cc-47fe-8ea1-4ba6a1a73221.png)
